### PR TITLE
Improvements and bug fixes

### DIFF
--- a/examples/cv_example.py
+++ b/examples/cv_example.py
@@ -7,7 +7,7 @@ def cv_scan_example():
     """
 
     # Basil configuration: adapt to your actual hardware
-    cv_config = {
+    cv_setup = {
         'transfer_layer': 
             [
             {'name': 'Visa',
@@ -34,7 +34,7 @@ def cv_scan_example():
 
     # CV scan
     cv.cv_scan(outfile='cv_scan_example.csv',
-               cv_config=cv_config,
+               cv_setup=cv_setup,
                smu_name='Sourcemeter',
                lcr_name='LCRMeter',
                ac_voltage=5e-3,

--- a/examples/iv_example.py
+++ b/examples/iv_example.py
@@ -7,11 +7,11 @@ def iv_scan_example():
     """
     In this example 3 basic IV scans are described with different parameters.
     Uncomment to run different scans.
-    Make sure that the *smu_config* describes your setup
+    Make sure that the *smu_setup* describes your setup
     """
 
     # Basil configuration: adapt to your actual hardware
-    smu_config = {
+    smu_setup = {
         'transfer_layer': 
             [{'name': 'Serial',
               'type': 'Serial',
@@ -27,7 +27,7 @@ def iv_scan_example():
 
     # Do iv scan
     iv.iv_scan(outfile='iv_scan_basic_example_1.csv',
-               smu_config=smu_config,
+               smu_setup=smu_setup,
                bias_voltage=60,  # IV scan from 0 to 60 V in 1 V steps
                current_limit=1e-6,  # Current limit in A
                n_meas=10,  # Take 10 measurements per given bias voltage and take the mean
@@ -39,7 +39,7 @@ def iv_scan_example():
 
     # # Do iv scan
     # iv.iv_scan(outfile='iv_scan_basic_example_2.h5',
-    #                  smu_config=smu_config,
+    #                  smu_setup=smu_setup,
     #                  bias_voltage=60,  # IV scan from 0 to 60 V in *bias_steps* equidistant steps
     #                  current_limit=1e-6,  # Current limit in A
     #                  bias_steps=20,  # Take 20 equidistant measurements between 0 and 60 V, same as bias_voltage=np.linspace(0, 60, 20)
@@ -48,7 +48,7 @@ def iv_scan_example():
 
     # # Do iv scan
     # iv.iv_scan(outfile='iv_scan_basic_example_3.h5',
-    #                  smu_config=smu_config,
+    #                  smu_setup=smu_setup,
     #                  bias_voltage=[0, 1, 2, 3, 4, 5, 10, 15, 20],  # IV scan with custom voltages
     #                  current_limit=1e-6,  # Current limit in A
     #                  log_progress=True,  # Show measurements of each bias step above progressbar

--- a/examples/iv_example.py
+++ b/examples/iv_example.py
@@ -7,11 +7,11 @@ def iv_scan_example():
     """
     In this example 3 basic IV scans are described with different parameters.
     Uncomment to run different scans.
-    Make sure that the *smu_setup* describes your setup
+    Make sure that the *iv_setup* describes your setup
     """
 
     # Basil configuration: adapt to your actual hardware
-    smu_setup = {
+    iv_setup = {
         'transfer_layer': 
             [{'name': 'Serial',
               'type': 'Serial',
@@ -27,7 +27,7 @@ def iv_scan_example():
 
     # Do iv scan
     iv.iv_scan(outfile='iv_scan_basic_example_1.csv',
-               smu_setup=smu_setup,
+               iv_setup=iv_setup,
                bias_voltage=60,  # IV scan from 0 to 60 V in 1 V steps
                current_limit=1e-6,  # Current limit in A
                n_meas=10,  # Take 10 measurements per given bias voltage and take the mean
@@ -39,7 +39,7 @@ def iv_scan_example():
 
     # # Do iv scan
     # iv.iv_scan(outfile='iv_scan_basic_example_2.h5',
-    #                  smu_setup=smu_setup,
+    #                  iv_setup=iv_setup,
     #                  bias_voltage=60,  # IV scan from 0 to 60 V in *bias_steps* equidistant steps
     #                  current_limit=1e-6,  # Current limit in A
     #                  bias_steps=20,  # Take 20 equidistant measurements between 0 and 60 V, same as bias_voltage=np.linspace(0, 60, 20)
@@ -48,7 +48,7 @@ def iv_scan_example():
 
     # # Do iv scan
     # iv.iv_scan(outfile='iv_scan_basic_example_3.h5',
-    #                  smu_setup=smu_setup,
+    #                  iv_setup=iv_setup,
     #                  bias_voltage=[0, 1, 2, 3, 4, 5, 10, 15, 20],  # IV scan with custom voltages
     #                  current_limit=1e-6,  # Current limit in A
     #                  log_progress=True,  # Show measurements of each bias step above progressbar

--- a/silab_collections/meas/cv.py
+++ b/silab_collections/meas/cv.py
@@ -53,10 +53,12 @@ def cv_scan(outfile, cv_setup, smu_name, lcr_name, ac_voltage, ac_frequency, bia
     # We already have an initialized DUT
     if isinstance(cv_setup, Dut):
         dut = cv_setup
+        _close_dut = False
     else:
-        # Initialize dut
+        # Initialize dut ourselves and therefore also close it afterwards
         dut = Dut(cv_setup)
         dut.init()
+        _close_dut = True
 
     # Initial check for HP 4284A LCR meter which is needed
     if not any(hwd['type'] == 'hp4284a' for hwd in dut._conf['hw_drivers']):
@@ -177,4 +179,5 @@ def cv_scan(outfile, cv_setup, smu_name, lcr_name, ac_voltage, ac_frequency, bia
         
         smu_utils.call_method_if_exists(smu, 'off')
 
-        dut.close()
+        if _close_dut:
+            dut.close()

--- a/silab_collections/meas/cv.py
+++ b/silab_collections/meas/cv.py
@@ -171,7 +171,6 @@ def cv_scan(outfile, cv_config, smu_name, lcr_name, ac_voltage, ac_frequency, bi
         except RuntimeError:
             pass
         
-        if hasattr(smu, 'off'):
-            smu.off()
+        smu_utils.call_method_if_exists(smu, 'off')
 
         dut.close()

--- a/silab_collections/meas/cv.py
+++ b/silab_collections/meas/cv.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from time import time, sleep, strftime
 
 
-def cv_scan(outfile, cv_config, smu_name, lcr_name, ac_voltage, ac_frequency, bias_voltage, current_limit, lcr_func='CPRP', bias_polarity=1, bias_settle_delay=5, bias_steps=None, n_meas=1, log_progress=False, **writer_kwargs):
+def cv_scan(outfile, cv_setup, smu_name, lcr_name, ac_voltage, ac_frequency, bias_voltage, current_limit, lcr_func='CPRP', bias_polarity=1, bias_settle_delay=5, bias_steps=None, n_meas=1, log_progress=False, **writer_kwargs):
     """
     CV scan using a single source-measure unit (SMU) as well as the HP4284A LCR meter.
 
@@ -20,12 +20,12 @@ def cv_scan(outfile, cv_config, smu_name, lcr_name, ac_voltage, ac_frequency, bi
     ----------
     outfile : str
         Output file to write to. By default the type is CSV, can be changed by passing the respective kwargs via **writer_kwargs
-    cv_config : str, dict, File
-        Config file passed to basil.dut.Dut of the respective setup devices, namely one SMU and LCR meter
+    cv_setup : str, dict, File, basil.dut.Dut
+        Config file passed to basil.dut.Dut of the respective setup devices, namely one SMU and LCR meter, or already initialized basil.dut.Dut
     smu_name : str
-        Name of SMU given in *cv_config*
+        Name of SMU given in *cv_setup*
     lcr_name : str
-        Name of LCR meter given in *cv_config*
+        Name of LCR meter given in *cv_setup*
     ac_voltage: float
         The AC voltage of the LCR meter in V. Typical values are in the order of 5 mV
     ac_frequency: float
@@ -50,9 +50,13 @@ def cv_scan(outfile, cv_config, smu_name, lcr_name, ac_voltage, ac_frequency, bi
     # Set bias settle delay to 5 seconds for large capacitances
     meas.BIAS_SETTLE_DELAY = bias_settle_delay
     
-    # Initialize dut
-    dut = Dut(cv_config)
-    dut.init()
+    # We already have an initialized DUT
+    if isinstance(cv_setup, Dut):
+        dut = cv_setup
+    else:
+        # Initialize dut
+        dut = Dut(cv_setup)
+        dut.init()
 
     # Initial check for HP 4284A LCR meter which is needed
     if not any(hwd['type'] == 'hp4284a' for hwd in dut._conf['hw_drivers']):

--- a/silab_collections/meas/iv.py
+++ b/silab_collections/meas/iv.py
@@ -39,7 +39,7 @@ def _measure_and_write_current(smu, n_meas, bias, writer, pbar, log):
         pbar.write(log)
 
 
-def iv_scan(outfile, smu_setup, bias_voltage, current_limit, bias_polarity=1, bias_steps=None, n_meas=1, smu_name=None, log_progress=False, linger=False, **writer_kwargs):
+def iv_scan(outfile, iv_setup, bias_voltage, current_limit, bias_polarity=1, bias_steps=None, n_meas=1, smu_name=None, log_progress=False, linger=False, **writer_kwargs):
     """
     Basic IV scan using a single source-measure unit (SMU).
 
@@ -47,7 +47,7 @@ def iv_scan(outfile, smu_setup, bias_voltage, current_limit, bias_polarity=1, bi
     ----------
     outfile : str
         Output file to write to. By default the type is CSV, can be changed by passing the respective kwargs via **writer_kwargs
-    smu_setup : str, dict, File, basil.dut.Dut
+    iv_setup : str, dict, File, basil.dut.Dut
         Config file passed to basil.dut.Dut of the respective SMU or already initialized Dut
     bias_voltage : float, int
         Maximum voltage to which the bias voltage is ramped
@@ -60,7 +60,7 @@ def iv_scan(outfile, smu_setup, bias_voltage, current_limit, bias_polarity=1, bi
     n_meas : int, optional
         Number of measurements per voltage step. If *n_meas* > 1, the mean is taken
     smu_name : str, optional
-        If given, it is used as smu = Dut[*smu_name*] to extract the SMU, if None *smu_setup* can only have one SMU, by default None
+        If given, it is used as smu = Dut[*smu_name*] to extract the SMU, if None *iv_setup* can only have one SMU, by default None
     log_progress: bool, optional
         Whether to print the measurements of each voltage step persistently over the progressbar
     linger : bool, float, optional
@@ -68,11 +68,11 @@ def iv_scan(outfile, smu_setup, bias_voltage, current_limit, bias_polarity=1, bi
     """
 
     # We already have an initialized DUT
-    if isinstance(smu_setup, Dut):
-        dut = smu_setup
+    if isinstance(iv_setup, Dut):
+        dut = iv_setup
     else:
         # Initialize dut
-        dut = Dut(smu_setup)
+        dut = Dut(iv_setup)
         dut.init()
 
     # Get SMU from dut
@@ -85,8 +85,8 @@ def iv_scan(outfile, smu_setup, bias_voltage, current_limit, bias_polarity=1, bi
         smu, = dut._hardware_layer.values()  # Fancy x, = container syntax
 
     else:
-        msg = "*smu_setup* contains more than 1 hardware driver, cannot identify SMU."
-        msg += "Set *smu_name* or only have the SMU hardware driver in *smu_setup*"
+        msg = "*iv_setup* contains more than 1 hardware driver, cannot identify SMU."
+        msg += "Set *smu_name* or only have the SMU hardware driver in *iv_setup*"
         raise ValueError(msg)
 
     # Generate array of bias voltages to loop over

--- a/silab_collections/meas/iv.py
+++ b/silab_collections/meas/iv.py
@@ -181,7 +181,6 @@ def iv_scan(outfile, smu_config, bias_voltage, current_limit, bias_polarity=1, b
         # Ensure we go back to 0 volts with the same stepping as IV measurements
         smu_utils.ramp_voltage(smu=smu, target_voltage=0, steps=len(bias_volts))
 
-        if hasattr(smu, 'off'):
-            smu.off()
+        smu_utils.call_method_if_exists(smu, 'off')
 
         dut.close()

--- a/silab_collections/meas/iv.py
+++ b/silab_collections/meas/iv.py
@@ -70,10 +70,12 @@ def iv_scan(outfile, iv_setup, bias_voltage, current_limit, bias_polarity=1, bia
     # We already have an initialized DUT
     if isinstance(iv_setup, Dut):
         dut = iv_setup
+        _close_dut = False
     else:
-        # Initialize dut
+        # Initialize dut ourselves and therefore also close it afterwards
         dut = Dut(iv_setup)
         dut.init()
+        _close_dut = True
 
     # Get SMU from dut
     # By name
@@ -187,4 +189,5 @@ def iv_scan(outfile, iv_setup, bias_voltage, current_limit, bias_polarity=1, bia
 
         smu_utils.call_method_if_exists(smu, 'off')
 
-        dut.close()
+        if _close_dut:
+            dut.close()

--- a/silab_collections/meas/iv.py
+++ b/silab_collections/meas/iv.py
@@ -39,7 +39,7 @@ def _measure_and_write_current(smu, n_meas, bias, writer, pbar, log):
         pbar.write(log)
 
 
-def iv_scan(outfile, smu_config, bias_voltage, current_limit, bias_polarity=1, bias_steps=None, n_meas=1, smu_name=None, log_progress=False, linger=False, **writer_kwargs):
+def iv_scan(outfile, smu_setup, bias_voltage, current_limit, bias_polarity=1, bias_steps=None, n_meas=1, smu_name=None, log_progress=False, linger=False, **writer_kwargs):
     """
     Basic IV scan using a single source-measure unit (SMU).
 
@@ -47,8 +47,8 @@ def iv_scan(outfile, smu_config, bias_voltage, current_limit, bias_polarity=1, b
     ----------
     outfile : str
         Output file to write to. By default the type is CSV, can be changed by passing the respective kwargs via **writer_kwargs
-    smu_config : str, dict, File
-        Config file passed to basil.dut.Dut of the respective SMU
+    smu_setup : str, dict, File, basil.dut.Dut
+        Config file passed to basil.dut.Dut of the respective SMU or already initialized Dut
     bias_voltage : float, int
         Maximum voltage to which the bias voltage is ramped
     current_limit : float
@@ -60,16 +60,20 @@ def iv_scan(outfile, smu_config, bias_voltage, current_limit, bias_polarity=1, b
     n_meas : int, optional
         Number of measurements per voltage step. If *n_meas* > 1, the mean is taken
     smu_name : str, optional
-        If given, it is used as smu = Dut[*smu_name*] to extract the SMU, if None *smu_config* can only have one SMU, by default None
+        If given, it is used as smu = Dut[*smu_name*] to extract the SMU, if None *smu_setup* can only have one SMU, by default None
     log_progress: bool, optional
         Whether to print the measurements of each voltage step persistently over the progressbar
     linger : bool, float, optional
         Whether to continue measuring IV when the *bias_voltage* has been reached. If True, measure until user interrupt, else measure *linger* seconds
     """
 
-    # Initialize dut
-    dut = Dut(smu_config)
-    dut.init()
+    # We already have an initialized DUT
+    if isinstance(smu_setup, Dut):
+        dut = smu_setup
+    else:
+        # Initialize dut
+        dut = Dut(smu_setup)
+        dut.init()
 
     # Get SMU from dut
     # By name
@@ -81,8 +85,8 @@ def iv_scan(outfile, smu_config, bias_voltage, current_limit, bias_polarity=1, b
         smu, = dut._hardware_layer.values()  # Fancy x, = container syntax
 
     else:
-        msg = "*smu_config* contains more than 1 hardware driver, cannot identify SMU."
-        msg += "Set *smu_name* or only have the SMU hardware driver in *smu_config*"
+        msg = "*smu_setup* contains more than 1 hardware driver, cannot identify SMU."
+        msg += "Set *smu_name* or only have the SMU hardware driver in *smu_setup*"
         raise ValueError(msg)
 
     # Generate array of bias voltages to loop over

--- a/silab_collections/meas/smu.py
+++ b/silab_collections/meas/smu.py
@@ -136,11 +136,15 @@ def setup_voltage_source(smu, bias_voltage, current_limit):
     # Ensure voltage range
     call_method_if_exists(smu, 'set_voltage_range', float(np.max(np.abs(bias_voltage)) if isinstance(bias_voltage, Iterable) else np.abs(bias_voltage)))
 
-    # Set voltage to 0 V
-    call_method_if_exists(smu, 'set_voltage', 0)
-
-    # Switch on SMU if possible from basil
-    call_method_if_exists(smu, 'on')
+    # Check if smu is already on
+    smu_is_on = call_method_if_exists(smu, 'get_on')
+    if smu_is_on is not None and bool(smu_is_on.strip()):
+        # If smu is already on we want to ramp down to 0 volt
+        ramp_voltage(smu, delay=0.2)
+    # if we cannot tell, just ramp to 0 and turn on
+    else:
+        call_method_if_exists(smu, 'set_voltage', 0)
+        call_method_if_exists(smu, 'on')
 
 
 def ramp_voltage(smu, target_voltage=0, delay=1, steps=None):

--- a/silab_collections/meas/smu.py
+++ b/silab_collections/meas/smu.py
@@ -39,7 +39,7 @@ def get_current_reading(smu):
         typ = get_smu_type(smu)
         if typ == 'KEITHLEY_2410':
             return float(smu.get_current().split(',')[1])
-        elif typ == 'KEITHLEY_6517A'.upper():
+        elif typ == 'KEITHLEY_6517A':
             return float(smu.get_read().split(',')[0][:-4])
         else:
             return float(smu.get_current())

--- a/silab_collections/meas/smu.py
+++ b/silab_collections/meas/smu.py
@@ -35,13 +35,14 @@ def get_current_reading(smu):
             smu.enable_formatting()
         return float(smu.get_current())
     else:
+        # Specifiy different smu type responses here; if not specified expect smu has get_current return value
         typ = get_smu_type(smu)
         if typ == 'KEITHLEY_2410':
             return float(smu.get_current().split(',')[1])
         elif typ == 'KEITHLEY_6517A'.upper():
-            return float(smu.get_current().split(',')[0][:-4])
+            return float(smu.get_read().split(',')[0][:-4])
         else:
-            return float(smu.get_current().split(',')[0])  # [1]
+            return float(smu.get_current())
 
 
 def get_voltage_reading(smu):
@@ -56,9 +57,9 @@ def get_voltage_reading(smu):
         if typ == 'KEITHLEY_2410':
             return float(smu.get_voltage().split(',')[0])
         elif typ == 'KEITHLEY_6517A':
-            return float(smu.get_voltage().split(',')[0][:-4])
+            return float(smu.get_read().split(',')[1][:-4])
         else:
-            return float(smu.get_voltage().split(',')[0])
+            return float(smu.get_voltage())
 
 def generate_bias_volts(bias, steps=None, polarity=1, check_monotonic=True):
     """
@@ -162,10 +163,6 @@ def ramp_voltage(smu, target_voltage=0, delay=1, steps=None):
     AttributeError:
         SMU does not have voltage getter/setter
     """
-
-    # Check for voltage getter and setter
-    if not all(hasattr(smu, f'{x}_voltage') for x in ('get', 'set')):
-        raise AttributeError("SMU does not have voltage getter/setter methods")
 
     smu_is_on = call_method_if_exists(smu, 'get_on')
     if smu_is_on is not None:

--- a/silab_collections/meas/smu.py
+++ b/silab_collections/meas/smu.py
@@ -57,7 +57,7 @@ def get_voltage_reading(smu):
         if typ == 'KEITHLEY_2410':
             return float(smu.get_voltage().split(',')[0])
         elif typ == 'KEITHLEY_6517A':
-            return float(smu.get_read().split(',')[1][:-4])
+            return float(smu.get_voltage())
         else:
             return float(smu.get_voltage())
 


### PR DESCRIPTION
- Allow to use Keithley 6517A electro meter with IV scans See #3 
- Allow to use already initialized Dut objects with IV and CV scans
- Fix testing for Dut object methods; `hasattr` not working because SCPI HL generates any method on the fly and only fails on calling the method